### PR TITLE
Invalid login message on login page

### DIFF
--- a/clatoolkit_project/clatoolkit/views.py
+++ b/clatoolkit_project/clatoolkit/views.py
@@ -36,6 +36,8 @@ def home(request):
 def userlogin(request):
     context = RequestContext(request)
 
+    message = None
+
     if request.method == 'POST':
         print "posted"
         username = request.POST['username']
@@ -52,12 +54,9 @@ def userlogin(request):
                 #print "sending to myunits"
                 return HttpResponseRedirect('/dashboard/myunits/')
             else:
-                # An inactive account was used - no logging in!
-                return HttpResponse("Your CLAToolkit account is disabled.")
+                message = "Your CLAToolkit account is disabled."
         else:
-            # Bad login details were provided. So we can't log the user in.
-            #print "Invalid login details: {0}, {1}".format(username, password)
-            return HttpResponse("Invalid login details supplied.")
+            message = "Invalid login details supplied."
 
     # The request is not a HTTP POST, so display the login form.
     # This scenario would most likely be a HTTP GET.
@@ -70,7 +69,7 @@ def userlogin(request):
         #print "ordinary get"
         # No context variables to pass to the template system, hence the
         # blank dictionary object...
-        return render_to_response('clatoolkit/login.html', {}, context)
+        return render_to_response('clatoolkit/login.html', {"message": message}, context)
 
 
 #Unit management integration for staff - 13/05/16

--- a/clatoolkit_project/templates/clatoolkit/login.html
+++ b/clatoolkit_project/templates/clatoolkit/login.html
@@ -17,6 +17,9 @@
                 <h3 class="panel-title">CLAToolkit: Login</h3>
             </div>
             <div class="panel-body">
+                {% if message %}
+                    <div class="alert alert-danger" role="alert">Error: {{ message }}</div>
+                {% endif %}
                 <form role="form" action="/" method="post">
                   {% csrf_token %}
                     <fieldset>


### PR DESCRIPTION
Login failure uses a bootstrap alert instead of returning a HttpResponse with an error message. 
