### PR TITLE
Add jwt retreival of user activities

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,10 @@ DB_PORT=5432
 AAF_URL=https://rapid.test.aaf.edu.au/jwt/authnrequest/research/your-custom-url-here
 AAF_SECRET=SECERET_USED_FOR_AAF_APP_REGISTRATION
 
+# API Secret for single consumer (can be extended)
+API_SECRET=supersecretsharedsecretstring
+# THIS MUST BE CHANGED TO YOUR FQDN
+API_URL=''
 
 # Set to 0 in production
 DEBUG=1

--- a/clatoolkit_project/clatoolkit_project/settings.py
+++ b/clatoolkit_project/clatoolkit_project/settings.py
@@ -60,6 +60,8 @@ EMAIL_PORT = 587
 EMAIL_HOST_USER = ''
 EMAIL_HOST_PASSWORD = ''
 #EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'  # During development only
+API_SECRET=os.environ.get('API_SECRET')
+API_URL=os.enivron.get('API_URL')
 
 # Application definition
 

--- a/clatoolkit_project/dashboard/utils.py
+++ b/clatoolkit_project/dashboard/utils.py
@@ -31,6 +31,23 @@ from xapi.statement.xapi_getter import xapi_getter
 from xapi.statement.xapi_filter import xapi_filter
 from xapi.oauth_consumer.operative import LRS_Auth
 
+def get_user_truncated_xapi(user, platforms=None, course_id=None):
+    user_lrs = LearningRecord.objects.filter(user_id=user)
+    if platforms:
+        platforms = [platform.capitalize() for platform in platforms]
+        user_lrs = user_lrs.filter(platform__in=platforms)
+    if course_id:
+        user_lrs = user_lrs.filter(unit_id=course_id)
+    data = []
+    for lr in user_lrs:
+        trunc_xapi = {}
+        trunc_xapi['verb'] = lr.verb
+        trunc_xapi['object'] = lr.platformid
+        trunc_xapi['date'] = lr.datetimestamp
+        trunc_xapi['platform'] = lr.platform
+        data.append(trunc_xapi)
+
+    return data
 
 
 def getPluginKey(platform):


### PR DESCRIPTION
- Added endpoint to access user activities
- Requires a JWT payload with {“user”: “username/email”} signed using
pre-shared key specified in .env, so only one “consumer” for now (could
easily be extended for many consumers though)
- JWT is added to the custom HTTP header “api-auth” (for some reason
the Authorisation header kept being stripped..), then sent to the
endpoint (/dashboard/api/get_user_activities).
- Can specify additional params so narrow search scope (GET, could be changed though) to get
specific results by unit/platform (e.g.:
/dashboard/api/get_user_activities?platform=twitter,github)

Output looks like:

{
    "user_activities": [
        {
            "date": "2017-02-17T08:55:53Z",
            "platform": "Twitter",
            "verb": "created",
            "object":"https://twitter.com/clatoolkitdev/status/832513891267547137"
        },
        {
            "date": "2017-02-17T03:47:55Z",
            "platform": "Twitter",
            "verb": "created",
            "object":"https://twitter.com/clatoolkitdev/status/832436387924238338"
        },
        {
            "date": "2017-03-18T03:07:20Z",
            "platform": "Twitter",
            "verb": "created",
            "object":"https://twitter.com/clatoolkitdev/status/842935421604528129"
        },
        {
            "date": "2017-03-18T03:05:51Z",
            "platform": "Twitter",
            "verb": "created",
            "object":"https://twitter.com/clatoolkitdev/status/842935049884377088"
        }
    ]
}